### PR TITLE
test: use atomic_queue lib over boost

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         cxx:
           - g++
-          - clang++
         build_type: [ Debug, Release ]
         std: [ 20 ]
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         cxx:
-          - g++-13
-          - clang++
+          - g++-11
+          - clang++-11
         build_type: [ Debug, Release ]
         std: [ 20 ]
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         cxx:
-          - g++-11
-          - clang++-11
+          - g++
+          - clang++
         build_type: [ Debug, Release ]
         std: [ 20 ]
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         cxx:
           - g++
-          - clang++
         build_type: [ Debug, Release ]
         std: [ 20 ]
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         cxx:
-          - g++-13
-          - clang++
+          - g++-11
+          - clang++-11
         build_type: [ Debug, Release ]
         std: [ 20 ]
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         cxx:
-          - g++-11
-          - clang++-11
+          - g++
+          - clang++
         build_type: [ Debug, Release ]
         std: [ 20 ]
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,16 +33,14 @@ include(CTest)
 include(Catch)
 catch_discover_tests(${PROJECT_NAME})
 
-# # Fetch and install Boost
-set(BOOST_INCLUDE_LIBRARIES lockfree)
-set(BOOST_ENABLE_CMAKE ON)
+# Fetch and install atomic_queue
 FetchContent_Declare(
-  Boost
-  GIT_REPOSITORY https://github.com/boostorg/boost.git
-  GIT_TAG boost-1.84.0)
-FetchContent_MakeAvailable(Boost)
+  atomic_queue
+  GIT_REPOSITORY https://github.com/yaneury/atomic_queue.git
+  GIT_TAG stable)
+FetchContent_MakeAvailable(atomic_queue)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Boost::lockfree)
+target_link_libraries(${PROJECT_NAME} PRIVATE atomic_queue)
 
 enable_testing()
 


### PR DESCRIPTION
Downloading boost was killing the CI jobs, blowing my free tier budget. No bueno.